### PR TITLE
FIX: scrolling the navbar could wipe away any titleTextAttributes previously set.

### DIFF
--- a/Classes/YIFullScreenScroll.m
+++ b/Classes/YIFullScreenScroll.m
@@ -529,7 +529,9 @@ static char __isFullScreenScrollViewKey;
                 // for non-customized title
                 UIColor *titleTextColor = navBar.titleTextAttributes[NSForegroundColorAttributeName] ?: [UIColor blackColor];
                 titleTextColor = [titleTextColor colorWithAlphaComponent:alpha];
-                [navBar setTitleTextAttributes:@{ NSForegroundColorAttributeName : titleTextColor }];
+                NSMutableDictionary *titleTextAttributes = [navBar.titleTextAttributes mutableCopy];
+                [titleTextAttributes setObject:titleTextColor forKey:NSForegroundColorAttributeName];
+                [navBar setTitleTextAttributes:titleTextAttributes];
                 
                 // for customized title
                 if (![_viewController.navigationItem.titleView conformsToProtocol:@protocol(YIFullScreenScrollNoFading)]) {


### PR DESCRIPTION
Currently, it is wiping away any custom titleTextAttributes set on the navBar, but only when electing to scroll it.  In my case, I was using a custom font, and that was getting blown away.  This fixes that.
